### PR TITLE
fix: broaden permissions for attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
       security-events: "write" # Needed to upload SARIF file to security tab
       id-token: "write" # Needed to get GH Token to attest
       attestations: "write" # Needed to upload attestation
+      artifact-metadata: "write" # Needed to create artifact metadata
       contents: "read"
     # enq: hash with name and version always longer than 80 chars
     # yamllint disable rule:line-length
@@ -131,6 +132,7 @@ jobs:
     # yamllint enable rule:line-length
     with:
       download: true
+      full-checkout: true
       download-name: "dist-${{ github.sha }}"
       # enq: long command, splitting is unreadable
       # yamllint disable rule:line-length
@@ -143,7 +145,6 @@ jobs:
       group: "release"
       # Full history to generate full changelog
       fetch-depth: 0
-      full-checkout: true
       upload-name: "CHANGELOGS-${{ github.sha }}"
       upload-path: "CHANGELOGS-${{ github.sha }}"
 
@@ -194,7 +195,7 @@ jobs:
       - name: "Harden Runner"
         # enq: hash with name and version always longer than 80 chars
         # yamllint disable rule:line-length
-        uses: "step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594" # v2.16.0
+        uses: "step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450" # v2.19.1
         # yamllint enable rule:line-length
         with:
           disable-sudo: true
@@ -203,7 +204,7 @@ jobs:
       - name: "Download artifacts"
         # enq: hash with name and version always longer than 80 chars
         # yamllint disable rule:line-length
-        uses: "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093" # v4.3.0
+        uses: "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c" # v8.0.1
         # yamllint enable rule:line-length
         with:
           name: "dist-${{ github.sha }}"
@@ -239,7 +240,7 @@ jobs:
       - name: "Upload artifacts"
         # enq: hash with name and version always longer than 80 chars
         # yamllint disable rule:line-length
-        uses: "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02" # v4.6.2
+        uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" # v7.0.1
         # yamllint enable rule:line-length
         with:
           name: "dist-${{ github.sha }}"


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2025 open-nudge <https://github.com/open-nudge>
SPDX-FileContributor: szymonmaszke <github@maszke.co>

SPDX-License-Identifier: Apache-2.0
-->

<!--- pyml disable-next-line first-line-heading,first-line-h1-->

## Checklist

- [x] I agree to follow this project's [Code of Conduct](https://github.com/open-nudge/loadfig/blob/main/CODE_OF_CONDUCT.md)
- [x] I have read this project's [Contributing Guide](https://github.com/open-nudge/loadfig/blob/main/CONTRIBUTING.md)
- [x] I have created relevant issue(s) and linked them in the PR description

> Closes #10 
